### PR TITLE
fix(ci): Skip Plot Evaluation in CI

### DIFF
--- a/etfdata/vignettes/analysis.qmd
+++ b/etfdata/vignettes/analysis.qmd
@@ -20,6 +20,7 @@ data_loaded <- FALSE
 universe <- NULL
 metadata <- NULL
 history <- NULL
+is_ci <- as.logical(Sys.getenv("CI", "false"))
 
 tryCatch({
   suppressPackageStartupMessages({
@@ -201,7 +202,7 @@ fetch_price_history("VUSA.L")
 ```{r history-plot}
 #| echo: true
 #| message: false
-#| eval: true
+#| eval: !expr !is_ci
 if (data_loaded && !is.null(history) && requireNamespace("ggplot2", quietly = TRUE)) {
   # Visualize Close Prices with Facets
   print(
@@ -225,7 +226,7 @@ We join the datasets and parse the AUM strings to analyze the relationship betwe
 
 ```{r combined}
 #| echo: true
-#| eval: true
+#| eval: !expr !is_ci
 if (data_loaded && !is.null(history) && !is.null(metadata)) {
   # Join data
   avg_vol <- history %>%
@@ -321,7 +322,7 @@ if (requireNamespace("targets", quietly = TRUE) &&
     
     # 2. Network Visualization
     # Skip interactive widget generation in CI to avoid potential rendering issues
-    if (!as.logical(Sys.getenv("CI", "false"))) {
+    if (!is_ci) {
       cat("### Pipeline Network\n")
       tryCatch({
         # visNetwork returns a widget, we need to print it or let it return for rendering


### PR DESCRIPTION
Prevents Quarto failures by skipping execution of ggplot chunks in CI, while keeping code visible.