### PR TITLE
fix(ci): Fix Quarto Chunk Options for Dynamic Eval

### DIFF
--- a/etfdata/vignettes/analysis.qmd
+++ b/etfdata/vignettes/analysis.qmd
@@ -199,10 +199,7 @@ We fetch daily price history from Yahoo Finance using `quantmod`.
 fetch_price_history("VUSA.L")
 ```
 
-```{r history-plot}
-#| echo: true
-#| message: false
-#| eval: !expr !is_ci
+```{r history-plot, echo=TRUE, message=FALSE, eval=!is_ci}
 if (data_loaded && !is.null(history) && requireNamespace("ggplot2", quietly = TRUE)) {
   # Visualize Close Prices with Facets
   print(
@@ -224,9 +221,7 @@ if (data_loaded && !is.null(history) && requireNamespace("ggplot2", quietly = TR
 
 We join the datasets and parse the AUM strings to analyze the relationship between Fund Size and Liquidity.
 
-```{r combined}
-#| echo: true
-#| eval: !expr !is_ci
+```{r combined, echo=TRUE, eval=!is_ci}
 if (data_loaded && !is.null(history) && !is.null(metadata)) {
   # Join data
   avg_vol <- history %>%


### PR DESCRIPTION
Replaces Quarto '#| eval: !expr' syntax with Knitr chunk headers to avoid Quarto parsing errors in CI.