### PR TITLE
Fix: Remove broken symlink

### DIFF
--- a/DEPLOYMENT_QUARTO_WEBSITE.md
+++ b/DEPLOYMENT_QUARTO_WEBSITE.md
@@ -1,1 +1,0 @@
-/Users/johngavin/docs_gh/llm/DEPLOYMENT_QUARTO_WEBSITE.md


### PR DESCRIPTION
Removes DEPLOYMENT_QUARTO_WEBSITE.md which was an absolute symlink breaking remote builds.