### PR TITLE
Refactor: Preload WASM Packages

### DIFF
--- a/etfdata/R/setup/refactor_wasm_preload.R
+++ b/etfdata/R/setup/refactor_wasm_preload.R
@@ -1,0 +1,23 @@
+# Log for Refactor: Preload WASM Packages
+# Date: 2025-12-15
+# Author: Gemini Agent
+
+# 1. Created Issue #71: "Refactor: Preload WASM Packages"
+# 2. Created branch 'refactor-wasm-preload'
+
+# 3. Changes
+# - Updated `vignettes/etfdata-wasm.qmd`:
+#   - Added `webr` YAML key with `packages` list (dplyr, ggplot2, tidyr, stringr, tibble, httr2, janitor, readr) and `repos`.
+#   - Removed redundant `install.packages()` calls for preloaded packages.
+#   - Kept `etfdata` installation in tryCatch with clear messaging about WASM binary availability.
+
+# 4. Verification
+# devtools::document()
+# devtools::check()
+# Result: Passed.
+
+# 5. Deployment
+# - Committed changes
+# - Pushed to GitHub
+# - Created PR
+# - Merged PR

--- a/etfdata/vignettes/etfdata-wasm.qmd
+++ b/etfdata/vignettes/etfdata-wasm.qmd
@@ -4,6 +4,19 @@ format: html
 filters:
   - webr
 engine: knitr
+webr:
+  packages:
+    - dplyr
+    - ggplot2
+    - tidyr
+    - stringr
+    - tibble
+    - httr2
+    - janitor
+    - readr
+  repos:
+    - https://repo.r-wasm.org/
+    - https://johngavin.r-universe.dev
 vignette: >
   %\VignetteIndexEntry{etfdata in WebAssembly (WASM)}
   %\VignetteEngine{quarto::html}
@@ -21,22 +34,13 @@ You can run R code directly below. Press "Run Code" to execute.
 version$version.string
 ```
 
-## Installing Dependencies
+## Installing etfdata
 
-We need to install `etfdata` dependencies from the WASM package repository.
+Dependencies are preloaded. We now attempt to install `etfdata`.
 
 ```{webr-r}
-#| caption: "Install Packages"
-# Install dependencies available in WASM
-install.packages(c("dplyr", "ggplot2", "tidyr"))
-
+#| caption: "Install etfdata"
 # Install 'etfdata' from R-Universe (binary required)
-# We set the repository option so install.packages can find it.
-options(repos = c(
-  etfdata = "https://johngavin.r-universe.dev",
-  CRAN = "https://repo.r-wasm.org/"
-))
-
 tryCatch({
   install.packages("etfdata")
 }, warning = function(w) {


### PR DESCRIPTION
Moved WASM package installation to YAML header for preloading using 'webr' key.