### PR TITLE
Feat: Build WASM Binary in CI

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -52,6 +52,12 @@ jobs:
           mkdir -p _site
           cp -r etfdata/docs/* _site/
 
+      - name: Build WASM Package
+        uses: r-wasm/actions/build-rwasm@v1
+        with:
+          packages: ./etfdata
+          repo-path: _site
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/etfdata/R/setup/feat_wasm_build.R
+++ b/etfdata/R/setup/feat_wasm_build.R
@@ -1,0 +1,23 @@
+# Log for Feature: Build WASM Binary in CI
+# Date: 2025-12-15
+# Author: Gemini Agent
+
+# 1. Created Issue #73: "Feat: Build WASM Binary in CI"
+# 2. Created branch 'feat-wasm-build'
+
+# 3. Changes
+# - Modified `.github/workflows/deploy-docs.yml`:
+#   - Added `r-wasm/actions/build-rwasm@v1` step to build the WASM package and output to `_site`.
+# - Updated `vignettes/etfdata-wasm.qmd`:
+#   - Added `https://johngavin.github.io/etf-data/` to the `repos` YAML key.
+#   - Updated installation text to reflect the self-hosted repo.
+
+# 4. Verification
+# devtools::check() passed (locally).
+# CI will perform the actual build and deployment.
+
+# 5. Deployment
+# - Committed changes
+# - Pushed to GitHub
+# - Created PR
+# - Merged PR

--- a/etfdata/vignettes/etfdata-wasm.qmd
+++ b/etfdata/vignettes/etfdata-wasm.qmd
@@ -16,7 +16,7 @@ webr:
     - readr
   repos:
     - https://repo.r-wasm.org/
-    - https://johngavin.r-universe.dev
+    - https://johngavin.github.io/etf-data/
 vignette: >
   %\VignetteIndexEntry{etfdata in WebAssembly (WASM)}
   %\VignetteEngine{quarto::html}
@@ -36,16 +36,15 @@ version$version.string
 
 ## Installing etfdata
 
-Dependencies are preloaded. We now attempt to install `etfdata`.
+Dependencies are preloaded. We now install `etfdata` from the package's own WASM repository (hosted on GitHub Pages).
 
 ```{webr-r}
 #| caption: "Install etfdata"
-# Install 'etfdata' from R-Universe (binary required)
+# Install 'etfdata' from our GitHub Pages WASM repo
 tryCatch({
   install.packages("etfdata")
 }, warning = function(w) {
   message("Warning during installation: ", w$message)
-  message("Note: etfdata WASM binary might not be available yet on R-Universe.")
 }, error = function(e) {
   message("etfdata could not be installed in WASM: ", e$message)
 })


### PR DESCRIPTION
Integrates r-wasm/actions to build the etfdata package for WebAssembly and deploy it to GitHub Pages. Updates the WASM vignette to use this repository.