### PR TITLE
Refactor: Revert WASM build to use R-Universe

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -52,12 +52,6 @@ jobs:
           mkdir -p _site
           cp -r etfdata/docs/* _site/
 
-      - name: Build WASM Package
-        uses: r-wasm/actions/build-rwasm@v1
-        with:
-          packages: ./etfdata
-          repo-path: _site
-
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/etfdata/vignettes/etfdata-wasm.qmd
+++ b/etfdata/vignettes/etfdata-wasm.qmd
@@ -16,7 +16,7 @@ webr:
     - readr
   repos:
     - https://repo.r-wasm.org/
-    - https://johngavin.github.io/etf-data/
+    - https://johngavin.r-universe.dev
 vignette: >
   %\VignetteIndexEntry{etfdata in WebAssembly (WASM)}
   %\VignetteEngine{quarto::html}
@@ -36,11 +36,11 @@ version$version.string
 
 ## Installing etfdata
 
-Dependencies are preloaded. We now install `etfdata` from the package's own WASM repository (hosted on GitHub Pages).
+Dependencies are preloaded. We now install `etfdata` from the R-Universe WASM repository.
 
 ```{webr-r}
 #| caption: "Install etfdata"
-# Install 'etfdata' from our GitHub Pages WASM repo
+# Install 'etfdata' from R-Universe WASM repo
 tryCatch({
   install.packages("etfdata")
 }, warning = function(w) {


### PR DESCRIPTION
Reverted custom GitHub Actions WASM build step and updated vignette to use R-Universe, now that it provides WASM binaries.